### PR TITLE
feat(formatter): add output sanitization for JSON and structured formats

### DIFF
--- a/cmd/logwrap/main.go
+++ b/cmd/logwrap/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"slices"
 
+	"github.com/sgaunet/logwrap/pkg/apperrors"
 	"github.com/sgaunet/logwrap/pkg/config"
-	"github.com/sgaunet/logwrap/pkg/errors"
 	"github.com/sgaunet/logwrap/pkg/executor"
 	"github.com/sgaunet/logwrap/pkg/formatter"
 	"github.com/sgaunet/logwrap/pkg/processor"
@@ -129,7 +129,7 @@ func parseArgs(args []string) ([]string, []string, error) {
 
 			if arg == "-config" || arg == "-template" || arg == "-format" {
 				if i+1 >= len(args) {
-					return nil, nil, fmt.Errorf("%w: %s", errors.ErrOptionRequiresValue, arg)
+					return nil, nil, fmt.Errorf("%w: %s", apperrors.ErrOptionRequiresValue, arg)
 				}
 				i++
 				configArgs = append(configArgs, args[i])

--- a/cmd/logwrap/main_test.go
+++ b/cmd/logwrap/main_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/sgaunet/logwrap/pkg/errors"
+	"github.com/sgaunet/logwrap/pkg/apperrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -142,7 +142,7 @@ func TestParseArgs_Errors(t *testing.T) {
 			assert.Error(t, err)
 			assert.Nil(t, configArgs)
 			assert.Nil(t, command)
-			assert.ErrorIs(t, err, errors.ErrOptionRequiresValue)
+			assert.ErrorIs(t, err, apperrors.ErrOptionRequiresValue)
 			assert.Contains(t, err.Error(), tt.errorMsg)
 		})
 	}

--- a/pkg/apperrors/apperrors.go
+++ b/pkg/apperrors/apperrors.go
@@ -1,5 +1,5 @@
-// Package errors defines static errors used throughout the logwrap application.
-package errors
+// Package apperrors defines static errors used throughout the logwrap application.
+package apperrors
 
 import "errors"
 

--- a/pkg/apperrors/apperrors_test.go
+++ b/pkg/apperrors/apperrors_test.go
@@ -1,4 +1,4 @@
-package errors
+package apperrors
 
 import (
 	"errors"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/sgaunet/logwrap/pkg/errors"
+	"github.com/sgaunet/logwrap/pkg/apperrors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -235,13 +235,13 @@ func validateConfigPath(configFile string) error {
 	// Prevent path traversal attacks
 	cleaned := filepath.Clean(configFile)
 	if strings.Contains(cleaned, "..") {
-		return errors.ErrPathTraversal
+		return apperrors.ErrPathTraversal
 	}
 
 	// Only allow .yaml, .yml files
 	ext := strings.ToLower(filepath.Ext(cleaned))
 	if ext != ".yaml" && ext != ".yml" {
-		return errors.ErrInvalidFileType
+		return apperrors.ErrInvalidFileType
 	}
 
 	return nil

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -3,7 +3,7 @@ package config
 import (
 	"testing"
 
-	"github.com/sgaunet/logwrap/pkg/errors"
+	"github.com/sgaunet/logwrap/pkg/apperrors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -25,7 +25,7 @@ func TestConfig_ValidatePrefix_EmptyTemplate(t *testing.T) {
 
 	err := cfg.Validate()
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, errors.ErrTemplateEmpty)
+	assert.ErrorIs(t, err, apperrors.ErrTemplateEmpty)
 	assert.Contains(t, err.Error(), "prefix configuration error")
 }
 
@@ -53,7 +53,7 @@ func TestConfig_ValidateTimestamp(t *testing.T) {
 			name:         "empty format",
 			format:       "",
 			expectError:  true,
-			expectedErr:  errors.ErrTimestampFormatEmpty,
+			expectedErr:  apperrors.ErrTimestampFormatEmpty,
 			errorMessage: "timestamp format cannot be empty",
 		},
 	}
@@ -152,7 +152,7 @@ func TestConfig_ValidateColors(t *testing.T) {
 
 				if tt.expectError {
 					assert.Error(t, err)
-					assert.ErrorIs(t, err, errors.ErrInvalidColor)
+					assert.ErrorIs(t, err, apperrors.ErrInvalidColor)
 					assert.Contains(t, err.Error(), "invalid color")
 				} else {
 					assert.NoError(t, err)
@@ -205,7 +205,7 @@ func TestConfig_ValidateUser(t *testing.T) {
 
 			if tt.expectError {
 				assert.Error(t, err)
-				assert.ErrorIs(t, err, errors.ErrInvalidUserFormat)
+				assert.ErrorIs(t, err, apperrors.ErrInvalidUserFormat)
 				assert.Contains(t, err.Error(), "invalid user format")
 			} else {
 				assert.NoError(t, err)
@@ -253,7 +253,7 @@ func TestConfig_ValidatePID(t *testing.T) {
 
 			if tt.expectError {
 				assert.Error(t, err)
-				assert.ErrorIs(t, err, errors.ErrInvalidPIDFormat)
+				assert.ErrorIs(t, err, apperrors.ErrInvalidPIDFormat)
 				assert.Contains(t, err.Error(), "invalid PID format")
 			} else {
 				assert.NoError(t, err)
@@ -292,21 +292,21 @@ func TestConfig_ValidateOutput(t *testing.T) {
 			format:      "invalid",
 			buffer:      "line",
 			expectError: true,
-			expectedErr: errors.ErrInvalidOutputFormat,
+			expectedErr: apperrors.ErrInvalidOutputFormat,
 		},
 		{
 			name:        "invalid buffer",
 			format:      "text",
 			buffer:      "invalid",
 			expectError: true,
-			expectedErr: errors.ErrInvalidBufferMode,
+			expectedErr: apperrors.ErrInvalidBufferMode,
 		},
 		{
 			name:        "both invalid",
 			format:      "invalid",
 			buffer:      "invalid",
 			expectError: true,
-			expectedErr: errors.ErrInvalidOutputFormat, // First error encountered
+			expectedErr: apperrors.ErrInvalidOutputFormat, // First error encountered
 		},
 	}
 
@@ -362,14 +362,14 @@ func TestConfig_ValidateLogLevel(t *testing.T) {
 			stdoutLevel: "INVALID",
 			stderrLevel: "ERROR",
 			expectError: true,
-			expectedErr: errors.ErrInvalidStdoutLogLevel,
+			expectedErr: apperrors.ErrInvalidStdoutLogLevel,
 		},
 		{
 			name:        "invalid stderr level",
 			stdoutLevel: "INFO",
 			stderrLevel: "INVALID",
 			expectError: true,
-			expectedErr: errors.ErrInvalidStderrLogLevel,
+			expectedErr: apperrors.ErrInvalidStderrLogLevel,
 		},
 		{
 			name:           "invalid detection level",
@@ -378,7 +378,7 @@ func TestConfig_ValidateLogLevel(t *testing.T) {
 			detectionLevel: "invalid",
 			keywords:       []string{"ERROR"},
 			expectError:    true,
-			expectedErr:    errors.ErrInvalidLogLevel,
+			expectedErr:    apperrors.ErrInvalidLogLevel,
 		},
 		{
 			name:           "empty keywords",
@@ -387,7 +387,7 @@ func TestConfig_ValidateLogLevel(t *testing.T) {
 			detectionLevel: "error",
 			keywords:       []string{},
 			expectError:    true,
-			expectedErr:    errors.ErrNoDetectionKeywords,
+			expectedErr:    apperrors.ErrNoDetectionKeywords,
 		},
 	}
 
@@ -442,7 +442,7 @@ func TestConfig_ValidateLogLevel(t *testing.T) {
 
 			err := cfg.Validate()
 			assert.Error(t, err)
-			assert.ErrorIs(t, err, errors.ErrInvalidStdoutLogLevel)
+			assert.ErrorIs(t, err, apperrors.ErrInvalidStdoutLogLevel)
 		})
 
 		t.Run("invalid_stderr_level_"+level, func(t *testing.T) {
@@ -453,7 +453,7 @@ func TestConfig_ValidateLogLevel(t *testing.T) {
 
 			err := cfg.Validate()
 			assert.Error(t, err)
-			assert.ErrorIs(t, err, errors.ErrInvalidStderrLogLevel)
+			assert.ErrorIs(t, err, apperrors.ErrInvalidStderrLogLevel)
 		})
 	}
 }
@@ -553,5 +553,5 @@ func TestConfig_ValidateIntegration(t *testing.T) {
 	require.Error(t, err)
 
 	// Should fail on the first error (template empty)
-	assert.ErrorIs(t, err, errors.ErrTemplateEmpty)
+	assert.ErrorIs(t, err, apperrors.ErrTemplateEmpty)
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"syscall"
 
-	appErrors "github.com/sgaunet/logwrap/pkg/errors"
+	appErrors "github.com/sgaunet/logwrap/pkg/apperrors"
 )
 
 // Executor manages command execution with stream capture and signal handling.

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sgaunet/logwrap/pkg/errors"
+	"github.com/sgaunet/logwrap/pkg/apperrors"
 	"github.com/sgaunet/logwrap/pkg/executor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,7 +66,7 @@ func TestNew_EmptyCommand(t *testing.T) {
 	exec, err := executor.New([]string{})
 	assert.Error(t, err)
 	assert.Nil(t, exec)
-	assert.ErrorIs(t, err, errors.ErrCommandEmpty)
+	assert.ErrorIs(t, err, apperrors.ErrCommandEmpty)
 }
 
 func TestNew_PathTraversal(t *testing.T) {
@@ -97,7 +97,7 @@ func TestNew_PathTraversal(t *testing.T) {
 			exec, err := executor.New(tt.command)
 			assert.Error(t, err)
 			assert.Nil(t, exec)
-			assert.ErrorIs(t, err, errors.ErrCommandPathTraversal)
+			assert.ErrorIs(t, err, apperrors.ErrCommandPathTraversal)
 		})
 	}
 }
@@ -150,7 +150,7 @@ func TestExecutor_StartTwice(t *testing.T) {
 	// Start again - should fail
 	err = exec.Start()
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, errors.ErrExecutorStarted)
+	assert.ErrorIs(t, err, apperrors.ErrExecutorStarted)
 
 	// Clean up
 	_ = exec.Wait()
@@ -170,7 +170,7 @@ func TestExecutor_WaitWithoutStart(t *testing.T) {
 	// Wait without starting should fail
 	err = exec.Wait()
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, errors.ErrExecutorNotStarted)
+	assert.ErrorIs(t, err, apperrors.ErrExecutorNotStarted)
 }
 
 func TestExecutor_NonZeroExitCode(t *testing.T) {

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	pkgerrors "github.com/sgaunet/logwrap/pkg/errors"
+	pkgerrors "github.com/sgaunet/logwrap/pkg/apperrors"
 )
 
 // StreamType represents the type of stream (stdout or stderr).

--- a/pkg/processor/processor_test.go
+++ b/pkg/processor/processor_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/sgaunet/logwrap/internal/testutils"
-	"github.com/sgaunet/logwrap/pkg/errors"
+	"github.com/sgaunet/logwrap/pkg/apperrors"
 	"github.com/sgaunet/logwrap/pkg/processor"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -211,7 +211,7 @@ func TestProcessor_ProcessStreams_NilReaders(t *testing.T) {
 
 			err := p.ProcessStreams(ctx, tt.stdout, tt.stderr)
 			assert.Error(t, err)
-			assert.ErrorIs(t, err, errors.ErrReadersNil)
+			assert.ErrorIs(t, err, apperrors.ErrReadersNil)
 		})
 	}
 }
@@ -331,7 +331,7 @@ func TestProcessor_Wait_Timeout(t *testing.T) {
 	// Wait with short timeout should timeout
 	err := p.Wait(30 * time.Millisecond)
 	assert.Error(t, err)
-	assert.ErrorIs(t, err, errors.ErrProcessorTimeout)
+	assert.ErrorIs(t, err, apperrors.ErrProcessorTimeout)
 	assert.Contains(t, err.Error(), "30ms")
 
 	// Clean up - stop the processor to avoid goroutine leaks


### PR DESCRIPTION
Implement proper escaping and quoting for special characters in JSON
and structured output formats to prevent malformed output and security
issues.

Changes:
- Add intelligent quoting for structured format using strconv.Quote
- Add needsQuoting() to detect special characters requiring escaping
- Add comprehensive tests for sanitization edge cases
- Refactor pkg/errors to pkg/apperrors to avoid stdlib conflict
- Modernize validation loops with slices.Contains

Resolves #15