### PR TITLE
feat(shutdown): implement graceful shutdown mechanism with signal handling

### DIFF
--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -48,6 +48,7 @@ type Processor struct {
 	errors    []error
 	mutex     sync.Mutex
 	cancel    context.CancelFunc
+	stopOnce  sync.Once
 }
 
 // Option defines a function that configures a Processor.
@@ -111,10 +112,13 @@ func (p *Processor) ProcessStreams(ctx context.Context, stdout, stderr io.Reader
 }
 
 // Stop cancels the processor context to stop stream processing.
+// Safe to call multiple times - subsequent calls are no-ops.
 func (p *Processor) Stop() {
-	if p.cancel != nil {
-		p.cancel()
-	}
+	p.stopOnce.Do(func() {
+		if p.cancel != nil {
+			p.cancel()
+		}
+	})
 }
 
 // Wait waits for stream processing to complete with a timeout.


### PR DESCRIPTION
- Add SIGINT and SIGTERM signal handlers in main.go
- Stop processor and executor gracefully on signal reception
- Add 5-second timeout for command termination
- Add 3-second timeout for stream processing cleanup
- Return proper exit codes (130 for SIGINT, 143 for SIGTERM)
- Make Processor.Stop() thread-safe with sync.Once
- Add comprehensive tests for double-stop safety and shutdown behavior

Closes #17