### PR TITLE
fix(config,formatter): resolve bool flag override and non-deterministic log level detection

### DIFF
--- a/cmd/logwrap/main.go
+++ b/cmd/logwrap/main.go
@@ -112,10 +112,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := run(cfg, command); err != nil {
-		fmt.Fprintf(os.Stderr, "Execution error: %v\n", err)
-		os.Exit(1)
-	}
+	os.Exit(run(cfg, command))
 }
 
 func parseArgs(args []string) ([]string, []string, error) {
@@ -131,7 +128,7 @@ func parseArgs(args []string) ([]string, []string, error) {
 			break
 		}
 
-		if arg[0] == '-' {
+		if len(arg) > 0 && arg[0] == '-' {
 			configArgs = append(configArgs, arg)
 
 			if arg == "-config" || arg == "-template" || arg == "-format" {
@@ -165,21 +162,25 @@ func getConfigFile(args []string) string {
 	return config.FindConfigFile()
 }
 
-func run(cfg *config.Config, command []string) error {
+func run(cfg *config.Config, command []string) int {
 	exec, err := executor.New(command)
 	if err != nil {
-		return fmt.Errorf("failed to create executor: %w", err)
+		fmt.Fprintf(os.Stderr, "Execution error: failed to create executor: %v\n", err)
+		return 1
 	}
+	defer exec.Cleanup()
 
 	form, err := formatter.New(cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create formatter: %w", err)
+		fmt.Fprintf(os.Stderr, "Execution error: failed to create formatter: %v\n", err)
+		return 1
 	}
 
 	proc := processor.New(form, os.Stdout)
 
 	if err := exec.Start(); err != nil {
-		return fmt.Errorf("failed to start command: %w", err)
+		fmt.Fprintf(os.Stderr, "Execution error: failed to start command: %v\n", err)
+		return 1
 	}
 
 	stdout, stderr := exec.GetStreams()
@@ -204,10 +205,7 @@ func run(cfg *config.Config, command []string) error {
 	// Clean up signal handler before exit
 	signal.Stop(sigChan)
 
-	// Determine final exit code and exit
-	exitCode := determineExitCode(exec, receivedSignal, cmdErr)
-	os.Exit(exitCode)
-	return nil
+	return determineExitCode(exec, receivedSignal, cmdErr)
 }
 
 func waitForCommandOrSignal(

--- a/cmd/logwrap/main_test.go
+++ b/cmd/logwrap/main_test.go
@@ -323,6 +323,16 @@ func TestParseArgs_EdgeCases(t *testing.T) {
 	}
 }
 
+func TestParseArgs_EmptyStringArgument(t *testing.T) {
+	t.Parallel()
+
+	// An empty string element in args should not cause a panic
+	configArgs, command, err := parseArgs([]string{"", "echo"})
+	require.NoError(t, err)
+	assert.Nil(t, configArgs)
+	assert.Equal(t, []string{"", "echo"}, command)
+}
+
 func TestConstants(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -134,6 +134,7 @@ type CLIFlags struct {
 	OutputFormat  *string
 	Help          *bool
 	Version       *bool
+	setFlags      map[string]bool // tracks which flags were explicitly set on the command line
 }
 
 // LoadConfig loads configuration from file and applies CLI overrides.
@@ -236,6 +237,11 @@ func parseCLIFlags(args []string) (*CLIFlags, error) {
 		return nil, fmt.Errorf("failed to parse flags: %w", err)
 	}
 
+	flags.setFlags = make(map[string]bool)
+	fs.Visit(func(f *flag.Flag) {
+		flags.setFlags[f.Name] = true
+	})
+
 	return flags, nil
 }
 
@@ -243,10 +249,10 @@ func applyCLIOverrides(config *Config, flags *CLIFlags) {
 	if flags.Template != nil && *flags.Template != "" {
 		config.Prefix.Template = *flags.Template
 	}
-	if flags.TimestampUTC != nil {
+	if flags.setFlags["utc"] {
 		config.Prefix.Timestamp.UTC = *flags.TimestampUTC
 	}
-	if flags.ColorsEnabled != nil {
+	if flags.setFlags["colors"] {
 		config.Prefix.Colors.Enabled = *flags.ColorsEnabled
 	}
 	if flags.OutputFormat != nil && *flags.OutputFormat != "" {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -144,6 +144,49 @@ func TestLoadConfig_WithCLIOverrides(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_BoolFlagsDoNotOverrideConfigFile(t *testing.T) {
+	t.Parallel()
+
+	// Config file sets utc: true and colors.enabled: true
+	configContent := `
+prefix:
+  template: "[{{.Timestamp}}] [{{.Level}}] "
+  timestamp:
+    format: "%Y-%m-%d %H:%M:%S"
+    utc: true
+  colors:
+    enabled: true
+    info: "green"
+    error: "red"
+    timestamp: "blue"
+  user:
+    enabled: true
+    format: "username"
+  pid:
+    enabled: true
+    format: "decimal"
+output:
+  format: "text"
+log_level:
+  default_stdout: "INFO"
+  default_stderr: "ERROR"
+  detection:
+    enabled: true
+    keywords:
+      error: ["ERROR"]
+      info: ["INFO"]
+`
+	configFile := testutils.CreateTempConfigFile(t, configContent)
+
+	// Load with NO CLI args - bool flags should NOT override config file values
+	cfg, err := LoadConfig(configFile, []string{})
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	assert.True(t, cfg.Prefix.Timestamp.UTC, "utc: true from config file should not be overridden by flag default")
+	assert.True(t, cfg.Prefix.Colors.Enabled, "colors.enabled: true from config file should not be overridden by flag default")
+}
+
 func TestLoadConfig_InvalidCLIFlags(t *testing.T) {
 	t.Parallel()
 
@@ -447,6 +490,7 @@ func TestApplyCLIOverrides(t *testing.T) {
 		TimestampUTC:  &utc,
 		ColorsEnabled: &colors,
 		OutputFormat:  &format,
+		setFlags:      map[string]bool{"utc": true, "colors": true},
 	}
 
 	// Apply overrides
@@ -458,9 +502,11 @@ func TestApplyCLIOverrides(t *testing.T) {
 	assert.True(t, cfg.Prefix.Colors.Enabled)
 	assert.Equal(t, format, cfg.Output.Format)
 
-	// Test that nil values don't override
+	// Test that unset flags don't override
 	cfg2 := getDefaultConfig()
-	emptyFlags := &CLIFlags{}
+	emptyFlags := &CLIFlags{
+		setFlags: map[string]bool{},
+	}
 
 	applyCLIOverrides(cfg2, emptyFlags)
 
@@ -478,6 +524,7 @@ func TestApplyCLIOverrides(t *testing.T) {
 	emptyStringFlags := &CLIFlags{
 		Template:     &emptyString,
 		OutputFormat: &emptyString,
+		setFlags:     map[string]bool{},
 	}
 
 	applyCLIOverrides(cfg3, emptyStringFlags)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -41,9 +41,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -53,14 +51,13 @@ import (
 
 // Executor manages command execution with stream capture and signal handling.
 type Executor struct {
-	cmd         *exec.Cmd
-	cancel      context.CancelFunc
-	stdoutPipe  io.ReadCloser
-	stderrPipe  io.ReadCloser
-	signalChan  chan os.Signal
-	exitCode    int
-	isStarted   bool
-	isFinished  bool
+	cmd        *exec.Cmd
+	cancel     context.CancelFunc
+	stdoutPipe io.ReadCloser
+	stderrPipe io.ReadCloser
+	exitCode   int
+	isStarted  bool
+	isFinished bool
 }
 
 // New creates a new Executor instance for the given command.
@@ -94,11 +91,8 @@ func New(command []string) (*Executor, error) {
 		cancel:     cancel,
 		stdoutPipe: stdoutPipe,
 		stderrPipe: stderrPipe,
-		signalChan: make(chan os.Signal, 1),
 		exitCode:   0,
 	}
-
-	executor.setupSignalHandling()
 
 	return executor, nil
 }
@@ -129,9 +123,6 @@ func (e *Executor) Wait() error {
 
 	err := e.cmd.Wait()
 	e.isFinished = true
-
-	signal.Stop(e.signalChan)
-	close(e.signalChan)
 
 	if err != nil {
 		var exitError *exec.ExitError
@@ -205,20 +196,6 @@ func (e *Executor) Cleanup() {
 	if e.cancel != nil {
 		e.cancel()
 	}
-}
-
-func (e *Executor) setupSignalHandling() {
-	signal.Notify(e.signalChan, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
-
-	go func() {
-		for sig := range e.signalChan {
-			if e.isStarted && !e.isFinished {
-				if e.cmd.Process != nil {
-					_ = e.cmd.Process.Signal(sig)
-				}
-			}
-		}
-	}()
 }
 
 // validateCommand performs minimal security validation on the command path.

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -237,7 +237,14 @@ func (f *DefaultFormatter) getLogLevel(line string, streamType processor.StreamT
 
 	lineUpper := strings.ToUpper(line)
 
-	for level, keywords := range f.config.LogLevel.Detection.Keywords {
+	// Iterate in priority order to ensure deterministic detection
+	// when a line matches multiple levels (e.g., "INFO: An error occurred").
+	levelPriority := []string{"error", "warn", "info", "debug"}
+	for _, level := range levelPriority {
+		keywords, ok := f.config.LogLevel.Detection.Keywords[level]
+		if !ok {
+			continue
+		}
 		for _, keyword := range keywords {
 			if strings.Contains(lineUpper, strings.ToUpper(keyword)) {
 				return strings.ToUpper(level)

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -425,6 +425,44 @@ func TestGetLogLevel(t *testing.T) {
 	}
 }
 
+func TestGetLogLevel_AmbiguousKeywords_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		LogLevel: config.LogLevelConfig{
+			DefaultStdout: "INFO",
+			DefaultStderr: "ERROR",
+			Detection: config.DetectionConfig{
+				Enabled: true,
+				Keywords: map[string][]string{
+					"error": {"ERROR"},
+					"warn":  {"WARN"},
+					"debug": {"DEBUG"},
+					"info":  {"INFO"},
+				},
+			},
+		},
+	}
+
+	formatter, err := New(cfg)
+	require.NoError(t, err)
+
+	// A line containing both INFO and ERROR keywords should always
+	// return the same result across 1000 runs. Before the fix, map
+	// iteration order was random, so results varied.
+	line := "INFO: An error occurred ERROR"
+	results := make(map[string]int)
+	const iterations = 1000
+	for i := 0; i < iterations; i++ {
+		result := formatter.getLogLevel(line, processor.StreamStdout)
+		results[result]++
+	}
+
+	// Should always be classified as ERROR (higher priority than INFO)
+	assert.Len(t, results, 1, "log level detection should be deterministic: got %v", results)
+	assert.Equal(t, iterations, results["ERROR"], "line with both INFO and ERROR should be classified as ERROR")
+}
+
 func TestGetLogLevel_DetectionDisabled(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Track explicitly-set CLI flags via flag.Visit so bool defaults
  don't override config file values
- Iterate log level keywords in priority order (error > warn > info > debug)
  for deterministic detection
- Add bounds check for empty string in parseArgs
- Remove duplicate signal handling from executor
- Refactor run() to return exit code instead of calling os.Exit

Closes #46