### PR TITLE
fix(executor,formatter): fix signal exit codes, graceful shutdown, template validation, and output formatting

### DIFF
--- a/cmd/logwrap/main.go
+++ b/cmd/logwrap/main.go
@@ -235,10 +235,8 @@ func waitForCommandOrSignal(
 func handleSignalShutdown(exec *executor.Executor, proc *processor.Processor, sig os.Signal, cmdDone chan error) error {
 	fmt.Fprintf(os.Stderr, "\nReceived signal %v, initiating graceful shutdown...\n", sig)
 
-	// Stop the processor first
-	proc.Stop()
-
-	// Try to stop the executor gracefully
+	// Signal the child process first so it can produce cleanup output.
+	// The processor keeps running to capture any final output from the child.
 	if err := exec.Stop(); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to stop executor gracefully: %v\n", err)
 	}
@@ -249,13 +247,15 @@ func handleSignalShutdown(exec *executor.Executor, proc *processor.Processor, si
 
 	select {
 	case cmdErr := <-cmdDone:
-		// Command finished gracefully
+		// Command finished gracefully. Processor will finish naturally
+		// when the child's pipes close.
 		return cmdErr
 	case <-shutdownTimer.C:
 		fmt.Fprintf(os.Stderr, "Shutdown timeout exceeded, forcing kill...\n")
 		if err := exec.Kill(); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: failed to kill process: %v\n", err)
 		}
+		proc.Stop()
 		return <-cmdDone // Wait for process to actually die
 	}
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -22,9 +22,9 @@
 //
 // # Signal Handling
 //
-// The executor listens for SIGINT, SIGTERM, and SIGQUIT and forwards
-// them to the child process. This ensures the wrapped command receives
-// the same signals as logwrap itself.
+// When the executor's context is cancelled (via [Executor.Stop]),
+// the child process receives SIGTERM. If it doesn't exit within
+// [gracefulStopDelay], Go's stdlib escalates to SIGKILL.
 //
 // # Exit Code Preservation
 //
@@ -45,8 +45,18 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+	"time"
 
 	appErrors "github.com/sgaunet/logwrap/pkg/apperrors"
+)
+
+const (
+	// gracefulStopDelay is the time to wait after sending SIGTERM (via context
+	// cancellation) before the Go runtime escalates to SIGKILL.
+	gracefulStopDelay = 5 * time.Second
+
+	// signalExitCodeBase is the UNIX convention base for signal exit codes (128 + signal number).
+	signalExitCodeBase = 128
 )
 
 // Executor manages command execution with stream capture and signal handling.
@@ -72,6 +82,13 @@ func New(command []string) (*Executor, error) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cmd := exec.CommandContext(ctx, command[0], command[1:]...) // #nosec G204 - command is validated above
+
+	// Send SIGTERM (not SIGKILL) when the context is cancelled.
+	// If the process doesn't exit within WaitDelay, Go escalates to SIGKILL.
+	cmd.Cancel = func() error {
+		return cmd.Process.Signal(syscall.SIGTERM)
+	}
+	cmd.WaitDelay = gracefulStopDelay
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
@@ -127,13 +144,27 @@ func (e *Executor) Wait() error {
 	if err != nil {
 		var exitError *exec.ExitError
 		if errors.As(err, &exitError) {
-			e.exitCode = exitError.ExitCode()
+			e.exitCode = resolveExitCode(exitError)
 		} else {
 			return fmt.Errorf("command execution failed: %w", err)
 		}
 	}
 
 	return nil
+}
+
+// resolveExitCode extracts the exit code from an ExitError.
+// When the process was killed by a signal, ExitCode() returns -1;
+// in that case, compute 128 + signal number per UNIX convention.
+func resolveExitCode(exitError *exec.ExitError) int {
+	code := exitError.ExitCode()
+	if code != -1 {
+		return code
+	}
+	if status, ok := exitError.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+		return signalExitCodeBase + int(status.Signal())
+	}
+	return code
 }
 
 // GetStreams returns the stdout and stderr readers for the command.
@@ -152,29 +183,22 @@ func (e *Executor) IsFinished() bool {
 }
 
 // Stop gracefully terminates the command using SIGTERM.
+// Context cancellation triggers the custom Cancel function (SIGTERM).
+// If the process doesn't exit within WaitDelay, Go escalates to SIGKILL.
 func (e *Executor) Stop() error {
 	if !e.isStarted || e.isFinished {
 		return nil
 	}
 
 	e.cancel()
-
-	if e.cmd.Process != nil {
-		if err := e.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			return fmt.Errorf("failed to send SIGTERM: %w", err)
-		}
-	}
-
 	return nil
 }
 
-// Kill forcefully terminates the command.
+// Kill forcefully terminates the command with SIGKILL.
 func (e *Executor) Kill() error {
 	if !e.isStarted || e.isFinished {
 		return nil
 	}
-
-	e.cancel()
 
 	if e.cmd.Process != nil {
 		if err := e.cmd.Process.Kill(); err != nil {
@@ -182,6 +206,7 @@ func (e *Executor) Kill() error {
 		}
 	}
 
+	e.cancel()
 	return nil
 }
 

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -619,3 +619,79 @@ func TestExecutor_StateTransitions(t *testing.T) {
 	assert.True(t, exec.IsFinished())
 	assert.Equal(t, 0, exec.GetExitCode())
 }
+
+func TestExecutor_SignalExitCode(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Signal exit codes not applicable on Windows")
+	}
+
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		signal       string
+		expectedCode int
+	}{
+		{"SIGSEGV", "SEGV", 139},  // 128 + 11
+		{"SIGTERM", "TERM", 143},  // 128 + 15
+		{"SIGABRT", "ABRT", 134}, // 128 + 6
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			exec, err := executor.New([]string{"sh", "-c", "kill -" + tt.signal + " $$"})
+			require.NoError(t, err)
+			t.Cleanup(func() { exec.Cleanup() })
+
+			err = exec.Start()
+			require.NoError(t, err)
+
+			stdout, stderr := exec.GetStreams()
+			go func() { _, _ = io.Copy(io.Discard, stdout) }()
+			go func() { _, _ = io.Copy(io.Discard, stderr) }()
+
+			err = exec.Wait()
+			assert.NoError(t, err)
+			assert.True(t, exec.IsFinished())
+			assert.Equal(t, tt.expectedCode, exec.GetExitCode())
+		})
+	}
+}
+
+func TestExecutor_Stop_SendsSIGTERM(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Signal handling tests not reliable on Windows")
+	}
+
+	t.Parallel()
+
+	markerFile := fmt.Sprintf("%s/sigterm_%d", t.TempDir(), time.Now().UnixNano())
+
+	// Shell script that traps SIGTERM, writes a marker file, then exits.
+	// Using "sleep &; wait" so the trap handler fires immediately on SIGTERM
+	// (wait is interrupted by signals, unlike foreground sleep).
+	script := fmt.Sprintf(`trap 'echo received > %s; exit 0' TERM; sleep 30 & wait`, markerFile)
+	exec, err := executor.New([]string{"sh", "-c", script})
+	require.NoError(t, err)
+	t.Cleanup(func() { exec.Cleanup() })
+
+	err = exec.Start()
+	require.NoError(t, err)
+
+	stdout, stderr := exec.GetStreams()
+	go func() { _, _ = io.Copy(io.Discard, stdout) }()
+	go func() { _, _ = io.Copy(io.Discard, stderr) }()
+
+	// Give the process time to set up the trap
+	time.Sleep(200 * time.Millisecond)
+
+	err = exec.Stop()
+	assert.NoError(t, err)
+
+	_ = exec.Wait()
+
+	// Verify the marker file was created (SIGTERM trap handler ran)
+	assert.FileExists(t, markerFile, "SIGTERM trap should have created marker file")
+}

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -54,6 +54,7 @@ package formatter
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/user"
 	"strconv"
@@ -96,6 +97,15 @@ func New(cfg *config.Config) (*DefaultFormatter, error) {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}
 
+	// Validate template fields by executing with test data.
+	// Go's template parser validates syntax but not field names, so
+	// {{.Invalid}} parses fine but fails at Execute time. Catch this
+	// at startup rather than silently producing unprefixed output.
+	testData := TemplateData{Timestamp: "t", Level: "t", User: "t", PID: "t", Line: "t"}
+	if err := tmpl.Execute(io.Discard, testData); err != nil {
+		return nil, fmt.Errorf("invalid template: %w", err)
+	}
+
 	userInfo, err := user.Current()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user info: %w", err)
@@ -122,10 +132,6 @@ func New(cfg *config.Config) (*DefaultFormatter, error) {
 
 // FormatLine formats a log line according to the configured output format.
 func (f *DefaultFormatter) FormatLine(line string, streamType processor.StreamType) string {
-	if line == "" {
-		return line
-	}
-
 	data := f.buildTemplateData(line, streamType)
 
 	switch f.config.Output.Format {
@@ -159,9 +165,13 @@ func (f *DefaultFormatter) formatJSON(data TemplateData) string {
 	jsonData := map[string]any{
 		"timestamp": data.Timestamp,
 		"level":     data.Level,
-		"user":      data.User,
-		"pid":       data.PID,
 		"message":   data.Line,
+	}
+	if f.config.Prefix.User.Enabled {
+		jsonData["user"] = data.User
+	}
+	if f.config.Prefix.PID.Enabled {
+		jsonData["pid"] = data.PID
 	}
 
 	jsonBytes, err := json.Marshal(jsonData)
@@ -173,12 +183,18 @@ func (f *DefaultFormatter) formatJSON(data TemplateData) string {
 }
 
 func (f *DefaultFormatter) formatStructured(data TemplateData) string {
-	return fmt.Sprintf("timestamp=%s level=%s user=%s pid=%s message=%s",
-		quoteIfNeeded(data.Timestamp),
-		quoteIfNeeded(data.Level),
-		quoteIfNeeded(data.User),
-		quoteIfNeeded(data.PID),
-		strconv.Quote(data.Line)) // Always quote message field using strconv.Quote for proper escaping
+	parts := []string{
+		"timestamp=" + quoteIfNeeded(data.Timestamp),
+		"level=" + quoteIfNeeded(data.Level),
+	}
+	if f.config.Prefix.User.Enabled {
+		parts = append(parts, "user="+quoteIfNeeded(data.User))
+	}
+	if f.config.Prefix.PID.Enabled {
+		parts = append(parts, "pid="+quoteIfNeeded(data.PID))
+	}
+	parts = append(parts, "message="+strconv.Quote(data.Line))
+	return strings.Join(parts, " ")
 }
 
 // quoteIfNeeded quotes a string value if it contains special characters.

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -146,7 +146,7 @@ func TestFormatLine_TextFormat(t *testing.T) {
 			name:       "empty line",
 			line:       "",
 			streamType: processor.StreamStdout,
-			expected:   "",
+			expected:   "[INFO] ",
 		},
 	}
 
@@ -869,9 +869,9 @@ func TestFormatLine_EmptyLine(t *testing.T) {
 	formatter, err := New(cfg)
 	require.NoError(t, err)
 
-	// Empty lines should be returned as-is
+	// Empty lines should be formatted with prefix
 	result := formatter.FormatLine("", processor.StreamStdout)
-	assert.Equal(t, "", result)
+	assert.Equal(t, "[INFO] ", result)
 }
 
 func TestFormatLine_TemplateExecutionError(t *testing.T) {
@@ -1158,4 +1158,143 @@ func TestFormatLine_StructuredSanitization(t *testing.T) {
 			tt.validate(t, result)
 		})
 	}
+}
+
+func TestNew_InvalidTemplateVariable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+	}{
+		{
+			name:     "completely invalid field",
+			template: "[{{.Invalid}}] ",
+		},
+		{
+			name:     "mixed valid and invalid",
+			template: "[{{.Timestamp}}] [{{.Nonexistent}}] ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &config.Config{
+				Prefix: config.PrefixConfig{
+					Template: tt.template,
+					Timestamp: config.TimestampConfig{
+						Format: "%Y-%m-%d",
+					},
+				},
+			}
+
+			formatter, err := New(cfg)
+			assert.Error(t, err)
+			assert.Nil(t, formatter)
+			assert.Contains(t, err.Error(), "invalid template")
+		})
+	}
+}
+
+func TestFormatLine_EmptyLine_JSON(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Prefix: config.PrefixConfig{
+			Template: "[{{.Level}}] ",
+			Timestamp: config.TimestampConfig{
+				Format: "%Y-%m-%d",
+				UTC:    true,
+			},
+			User: config.UserConfig{Enabled: true, Format: "username"},
+			PID:  config.PIDConfig{Enabled: true, Format: "decimal"},
+		},
+		Output: config.OutputConfig{Format: "json"},
+		LogLevel: config.LogLevelConfig{
+			DefaultStdout: "INFO",
+			Detection:     config.DetectionConfig{Enabled: false},
+		},
+	}
+
+	formatter, err := New(cfg)
+	require.NoError(t, err)
+
+	result := formatter.FormatLine("", processor.StreamStdout)
+	assert.True(t, json.Valid([]byte(result)), "Empty line JSON output should be valid JSON, got: %s", result)
+
+	var jsonData map[string]any
+	err = json.Unmarshal([]byte(result), &jsonData)
+	require.NoError(t, err)
+	assert.Equal(t, "", jsonData["message"])
+	assert.Equal(t, "INFO", jsonData["level"])
+}
+
+func TestFormatLine_JSON_DisabledUserPID(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Prefix: config.PrefixConfig{
+			Template: "[{{.Level}}] ",
+			Timestamp: config.TimestampConfig{
+				Format: "%Y-%m-%d",
+				UTC:    true,
+			},
+			User: config.UserConfig{Enabled: false},
+			PID:  config.PIDConfig{Enabled: false},
+		},
+		Output: config.OutputConfig{Format: "json"},
+		LogLevel: config.LogLevelConfig{
+			DefaultStdout: "INFO",
+			Detection:     config.DetectionConfig{Enabled: false},
+		},
+	}
+
+	formatter, err := New(cfg)
+	require.NoError(t, err)
+
+	result := formatter.FormatLine("test message", processor.StreamStdout)
+
+	var jsonData map[string]any
+	err = json.Unmarshal([]byte(result), &jsonData)
+	require.NoError(t, err)
+
+	assert.Equal(t, "INFO", jsonData["level"])
+	assert.Equal(t, "test message", jsonData["message"])
+	assert.Contains(t, jsonData, "timestamp")
+	assert.NotContains(t, jsonData, "user", "user field should be omitted when disabled")
+	assert.NotContains(t, jsonData, "pid", "pid field should be omitted when disabled")
+}
+
+func TestFormatLine_Structured_DisabledUserPID(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Prefix: config.PrefixConfig{
+			Template: "[{{.Level}}] ",
+			Timestamp: config.TimestampConfig{
+				Format: "%Y-%m-%d",
+				UTC:    true,
+			},
+			User: config.UserConfig{Enabled: false},
+			PID:  config.PIDConfig{Enabled: false},
+		},
+		Output: config.OutputConfig{Format: "structured"},
+		LogLevel: config.LogLevelConfig{
+			DefaultStdout: "INFO",
+			Detection:     config.DetectionConfig{Enabled: false},
+		},
+	}
+
+	formatter, err := New(cfg)
+	require.NoError(t, err)
+
+	result := formatter.FormatLine("test message", processor.StreamStdout)
+
+	assert.Contains(t, result, "timestamp=")
+	assert.Contains(t, result, "level=INFO")
+	assert.Contains(t, result, "message=")
+	assert.NotContains(t, result, "user=", "user field should be omitted when disabled")
+	assert.NotContains(t, result, "pid=", "pid field should be omitted when disabled")
 }


### PR DESCRIPTION
- Extract signal number from WaitStatus for proper 128+signal exit codes
- Set cmd.Cancel to send SIGTERM with WaitDelay auto-escalation to SIGKILL
- Reorder shutdown: signal child first, stop processor only on timeout
- Validate template fields at startup via test execution
- Format empty lines instead of passing through bare
- Omit disabled user/pid fields from JSON and structured output

Closes #48