### PR TITLE
feat(executor): forward stdin to child process

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -41,6 +41,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -89,6 +90,7 @@ func New(command []string) (*Executor, error) {
 		return cmd.Process.Signal(syscall.SIGTERM)
 	}
 	cmd.WaitDelay = gracefulStopDelay
+	cmd.Stdin = os.Stdin
 
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {


### PR DESCRIPTION
Set cmd.Stdin = os.Stdin so pipe-based workflows work:
cat file | logwrap -- grep pattern

Closes #50