### PR TITLE
fix(config,filter,formatter): resolve theme color override, FATAL/TRACE detection, and empty pattern bugs

### DIFF
--- a/pkg/apperrors/apperrors.go
+++ b/pkg/apperrors/apperrors.go
@@ -25,6 +25,7 @@ var (
 	ErrNoDetectionKeywords         = errors.New("log level has no detection keywords")
 	ErrEmptyKeyword                = errors.New("empty keyword in detection keywords")
 	ErrDetectionDisabledWithKeywords = errors.New("detection disabled but keywords are configured")
+	ErrEmptyFilterPattern            = errors.New("empty string in filter patterns is not allowed")
 )
 
 // Command line errors.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -154,10 +154,13 @@ type CLIFlags struct {
 func LoadConfig(configFile string, args []string) (*Config, error) {
 	config := getDefaultConfig()
 
+	var explicit explicitColorFields
+
 	if configFile != "" {
 		if err := loadConfigFile(config, configFile); err != nil {
 			return nil, fmt.Errorf("failed to load config file: %w", err)
 		}
+		explicit = detectExplicitColorFields(configFile)
 	}
 
 	flags, err := parseCLIFlags(args)
@@ -167,11 +170,24 @@ func LoadConfig(configFile string, args []string) (*Config, error) {
 
 	applyCLIOverrides(config, flags)
 
-	// Apply color theme if set. Theme provides defaults; explicit color
-	// fields in the config or CLI override theme values.
+	// Apply color theme if set. Theme provides base colors; explicit
+	// color fields from the config file or CLI override theme values.
 	if config.Prefix.Colors.Theme != "" {
+		savedColors := config.Prefix.Colors
+
 		if err := applyTheme(&config.Prefix.Colors, config.Prefix.Colors.Theme); err != nil {
 			return nil, fmt.Errorf("invalid configuration: %w", err)
+		}
+
+		// Restore colors explicitly set in the config file
+		if explicit.info {
+			config.Prefix.Colors.Info = savedColors.Info
+		}
+		if explicit.errColor {
+			config.Prefix.Colors.Error = savedColors.Error
+		}
+		if explicit.timestamp {
+			config.Prefix.Colors.Timestamp = savedColors.Timestamp
 		}
 	}
 
@@ -180,6 +196,44 @@ func LoadConfig(configFile string, args []string) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+// explicitColorFields tracks which color fields were explicitly set in the config file.
+type explicitColorFields struct {
+	info      bool
+	errColor  bool
+	timestamp bool
+}
+
+// detectExplicitColorFields re-reads the YAML config to determine which color
+// fields were explicitly set (as opposed to inherited from defaults).
+func detectExplicitColorFields(configFile string) explicitColorFields {
+	var fields explicitColorFields
+
+	data, err := os.ReadFile(configFile) // #nosec G304 - path already validated by loadConfigFile
+	if err != nil {
+		return fields
+	}
+
+	var raw struct {
+		Prefix struct {
+			Colors struct {
+				Info      *string `yaml:"info"`
+				Error     *string `yaml:"error"`
+				Timestamp *string `yaml:"timestamp"`
+			} `yaml:"colors"`
+		} `yaml:"prefix"`
+	}
+
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return fields
+	}
+
+	fields.info = raw.Prefix.Colors.Info != nil
+	fields.errColor = raw.Prefix.Colors.Error != nil
+	fields.timestamp = raw.Prefix.Colors.Timestamp != nil
+
+	return fields
 }
 
 func getDefaultConfig() *Config {

--- a/pkg/config/themes_test.go
+++ b/pkg/config/themes_test.go
@@ -126,6 +126,49 @@ log_level:
 	assert.Equal(t, "magenta", cfg.Prefix.Colors.Timestamp)
 }
 
+func TestLoadConfig_ThemeWithExplicitColorOverrides(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `
+prefix:
+  template: "[{{.Level}}] "
+  timestamp:
+    format: "%H:%M:%S"
+  colors:
+    enabled: true
+    theme: "warm"
+    info: cyan
+    error: green
+  user:
+    enabled: false
+    format: "username"
+  pid:
+    enabled: false
+    format: "decimal"
+output:
+  format: "text"
+log_level:
+  default_stdout: "INFO"
+  default_stderr: "ERROR"
+  detection:
+    enabled: true
+    keywords:
+      error: ["ERROR"]
+`
+	tmpDir := t.TempDir()
+	configPath := tmpDir + "/config.yaml"
+	require.NoError(t, writeTestFile(configPath, yamlContent))
+
+	cfg, err := LoadConfig(configPath, nil)
+	require.NoError(t, err)
+
+	// Explicit YAML colors should override theme values
+	assert.Equal(t, "cyan", cfg.Prefix.Colors.Info, "explicit info color should override theme")
+	assert.Equal(t, "green", cfg.Prefix.Colors.Error, "explicit error color should override theme")
+	// Timestamp not set explicitly — should use warm theme's value
+	assert.Equal(t, "magenta", cfg.Prefix.Colors.Timestamp, "non-explicit timestamp should use theme value")
+}
+
 func TestLoadConfig_InvalidTheme(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -31,6 +31,10 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("log level configuration error: %w", err)
 	}
 
+	if err := c.validateFilter(); err != nil {
+		return fmt.Errorf("filter configuration error: %w", err)
+	}
+
 	return nil
 }
 
@@ -327,6 +331,21 @@ func isValidLogLevel(level string, validLevels []string) bool {
 	}
 
 	return false
+}
+
+// validateFilter validates filter patterns.
+//
+// Empty strings in exclude_patterns or include_patterns are rejected because
+// an empty regex matches every line, which would silently drop or pass all
+// output — almost certainly a configuration mistake.
+func (c *Config) validateFilter() error {
+	if slices.Contains(c.Filter.ExcludePatterns, "") {
+		return fmt.Errorf("%w in exclude_patterns", apperrors.ErrEmptyFilterPattern)
+	}
+	if slices.Contains(c.Filter.IncludePatterns, "") {
+		return fmt.Errorf("%w in include_patterns", apperrors.ErrEmptyFilterPattern)
+	}
+	return nil
 }
 
 func getValidColorsString() string {

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -986,3 +986,40 @@ func TestConfig_ValidateOutputFormat_AllFormats(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_ValidateFilter_EmptyPatterns(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		exclude     []string
+		include     []string
+		expectError bool
+	}{
+		{"valid patterns", []string{"heartbeat"}, []string{"important"}, false},
+		{"no patterns", nil, nil, false},
+		{"empty exclude pattern", []string{""}, nil, true},
+		{"empty include pattern", nil, []string{""}, true},
+		{"empty among valid exclude", []string{"valid", ""}, nil, true},
+		{"empty among valid include", nil, []string{"valid", ""}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := getDefaultConfig()
+			cfg.Filter.ExcludePatterns = tt.exclude
+			cfg.Filter.IncludePatterns = tt.include
+
+			err := cfg.Validate()
+			if tt.expectError {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, apperrors.ErrEmptyFilterPattern)
+				assert.Contains(t, err.Error(), "filter configuration error")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/filter/filter.go
+++ b/pkg/filter/filter.go
@@ -124,8 +124,8 @@ func (f *Filter) matchesAny(line string, patterns []*regexp.Regexp) bool {
 // detectLevel returns the uppercase level name for a line, or empty string if none detected.
 // Uses the same keyword scanning approach as the formatter but with simplified priority.
 func (f *Filter) detectLevel(lineUpper string) string {
-	// Check levels in a deterministic priority order.
-	priorities := []string{"ERROR", "WARN", "INFO", "DEBUG"}
+	// Check levels in deterministic priority order (most to least severe).
+	priorities := []string{"FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"}
 	for _, level := range priorities {
 		keywords := f.levelKeywords[level]
 		for _, kw := range keywords {

--- a/pkg/filter/filter_test.go
+++ b/pkg/filter/filter_test.go
@@ -212,3 +212,49 @@ func TestFilter_CaseInsensitiveLevels(t *testing.T) {
 	assert.False(t, f.ShouldInclude("DEBUG: variable dump"))
 	assert.True(t, f.ShouldInclude("ERROR: failed"))
 }
+
+func TestFilter_FatalAndTraceLevels(t *testing.T) {
+	t.Parallel()
+
+	keywords := map[string][]string{
+		"fatal": {"FATAL"},
+		"error": {"ERROR"},
+		"warn":  {"WARN"},
+		"info":  {"INFO"},
+		"debug": {"DEBUG"},
+		"trace": {"TRACE"},
+	}
+
+	t.Run("include_fatal", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := New(Config{IncludeLevels: []string{"FATAL"}}, keywords)
+		require.NoError(t, err)
+
+		assert.True(t, f.ShouldInclude("FATAL: system crash"))
+		assert.False(t, f.ShouldInclude("ERROR: something"))
+		assert.False(t, f.ShouldInclude("INFO: started"))
+	})
+
+	t.Run("include_trace", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := New(Config{IncludeLevels: []string{"TRACE"}}, keywords)
+		require.NoError(t, err)
+
+		assert.True(t, f.ShouldInclude("TRACE: entering function"))
+		assert.False(t, f.ShouldInclude("DEBUG: variable"))
+		assert.False(t, f.ShouldInclude("INFO: started"))
+	})
+
+	t.Run("exclude_fatal", func(t *testing.T) {
+		t.Parallel()
+
+		f, err := New(Config{ExcludeLevels: []string{"FATAL"}}, keywords)
+		require.NoError(t, err)
+
+		assert.False(t, f.ShouldInclude("FATAL: system crash"))
+		assert.True(t, f.ShouldInclude("ERROR: something"))
+		assert.True(t, f.ShouldInclude("INFO: started"))
+	})
+}

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -270,7 +270,7 @@ func (f *DefaultFormatter) getLogLevel(line string, streamType processor.StreamT
 
 	// Iterate in priority order to ensure deterministic detection
 	// when a line matches multiple levels (e.g., "INFO: An error occurred").
-	levelPriority := []string{"error", "warn", "info", "debug"}
+	levelPriority := []string{"fatal", "error", "warn", "info", "debug", "trace"}
 	for _, level := range levelPriority {
 		keywords, ok := f.config.LogLevel.Detection.Keywords[level]
 		if !ok {

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -425,6 +425,51 @@ func TestGetLogLevel(t *testing.T) {
 	}
 }
 
+func TestGetLogLevel_FatalAndTraceKeywordKeys(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		LogLevel: config.LogLevelConfig{
+			DefaultStdout: "INFO",
+			DefaultStderr: "ERROR",
+			Detection: config.DetectionConfig{
+				Enabled: true,
+				Keywords: map[string][]string{
+					"fatal": {"FATAL"},
+					"error": {"ERROR"},
+					"warn":  {"WARN"},
+					"info":  {"INFO"},
+					"debug": {"DEBUG"},
+					"trace": {"TRACE"},
+				},
+			},
+		},
+	}
+
+	formatter, err := New(cfg)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		line     string
+		expected string
+	}{
+		{"FATAL detected", "FATAL: system crash", "FATAL"},
+		{"TRACE detected", "TRACE: entering function", "TRACE"},
+		{"ERROR still works", "ERROR: connection failed", "ERROR"},
+		{"FATAL has priority over ERROR", "FATAL ERROR occurred", "FATAL"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := formatter.getLogLevel(tt.line, processor.StreamStdout)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestGetLogLevel_AmbiguousKeywords_Deterministic(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Preserve explicit YAML color fields when applying a theme by
  detecting which fields were explicitly set and restoring them
  after theme application
- Add FATAL and TRACE to filter detectLevel priority list so
  include_levels/exclude_levels work for all valid log levels
- Add fatal and trace to formatter getLogLevel priority list so
  custom keyword keys are detected in log output
- Add validateFilter to reject empty strings in exclude_patterns
  and include_patterns (empty regex silently matches everything)
- Add ErrEmptyFilterPattern sentinel error
- Add tests for all four fixes

Closes #64