### PR TITLE
fix(config,main): resolve detection disabled validation, -config=value parsing, and -validate output

### DIFF
--- a/cmd/logwrap/main.go
+++ b/cmd/logwrap/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"slices"
+	"strings"
 	"syscall"
 	"time"
 
@@ -158,18 +159,53 @@ func validateConfig(args []string) int {
 
 	_, _ = fmt.Fprintf(os.Stdout, "Configuration is valid\n\n")
 	_, _ = fmt.Fprintf(os.Stdout, "Loaded from: %s\n\n", source)
+	printConfigSettings(cfg)
+	return 0
+}
+
+func printConfigSettings(cfg *config.Config) {
 	_, _ = fmt.Fprintf(os.Stdout, "Settings:\n")
 	_, _ = fmt.Fprintf(os.Stdout, "  Output format:    %s\n", cfg.Output.Format)
 	_, _ = fmt.Fprintf(os.Stdout, "  Template:         %s\n", cfg.Prefix.Template)
 	_, _ = fmt.Fprintf(os.Stdout, "  Timestamp format: %s\n", cfg.Prefix.Timestamp.Format)
 	_, _ = fmt.Fprintf(os.Stdout, "  Timestamp UTC:    %t\n", cfg.Prefix.Timestamp.UTC)
 	_, _ = fmt.Fprintf(os.Stdout, "  Colors:           %t\n", cfg.Prefix.Colors.Enabled)
+	if cfg.Prefix.Colors.Enabled {
+		printColorSettings(cfg)
+	}
 	_, _ = fmt.Fprintf(os.Stdout, "  User:             %t (%s)\n", cfg.Prefix.User.Enabled, cfg.Prefix.User.Format)
 	_, _ = fmt.Fprintf(os.Stdout, "  PID:              %t (%s)\n", cfg.Prefix.PID.Enabled, cfg.Prefix.PID.Format)
 	_, _ = fmt.Fprintf(os.Stdout, "  Default stdout:   %s\n", cfg.LogLevel.DefaultStdout)
 	_, _ = fmt.Fprintf(os.Stdout, "  Default stderr:   %s\n", cfg.LogLevel.DefaultStderr)
 	_, _ = fmt.Fprintf(os.Stdout, "  Detection:        %t\n", cfg.LogLevel.Detection.Enabled)
-	return 0
+	if cfg.Filter.Enabled {
+		printFilterSettings(cfg)
+	}
+}
+
+func printColorSettings(cfg *config.Config) {
+	if cfg.Prefix.Colors.Theme != "" {
+		_, _ = fmt.Fprintf(os.Stdout, "    Theme:          %s\n", cfg.Prefix.Colors.Theme)
+	}
+	_, _ = fmt.Fprintf(os.Stdout, "    Info:           %s\n", cfg.Prefix.Colors.Info)
+	_, _ = fmt.Fprintf(os.Stdout, "    Error:          %s\n", cfg.Prefix.Colors.Error)
+	_, _ = fmt.Fprintf(os.Stdout, "    Timestamp:      %s\n", cfg.Prefix.Colors.Timestamp)
+}
+
+func printFilterSettings(cfg *config.Config) {
+	_, _ = fmt.Fprintf(os.Stdout, "  Filter:           true\n")
+	if len(cfg.Filter.IncludeLevels) > 0 {
+		_, _ = fmt.Fprintf(os.Stdout, "    Include levels: %s\n", strings.Join(cfg.Filter.IncludeLevels, ", "))
+	}
+	if len(cfg.Filter.ExcludeLevels) > 0 {
+		_, _ = fmt.Fprintf(os.Stdout, "    Exclude levels: %s\n", strings.Join(cfg.Filter.ExcludeLevels, ", "))
+	}
+	if len(cfg.Filter.IncludePatterns) > 0 {
+		_, _ = fmt.Fprintf(os.Stdout, "    Include patterns: %s\n", strings.Join(cfg.Filter.IncludePatterns, ", "))
+	}
+	if len(cfg.Filter.ExcludePatterns) > 0 {
+		_, _ = fmt.Fprintf(os.Stdout, "    Exclude patterns: %s\n", strings.Join(cfg.Filter.ExcludePatterns, ", "))
+	}
 }
 
 func parseArgs(args []string) ([]string, []string, error) {
@@ -214,6 +250,9 @@ func getConfigFile(args []string) string {
 	for i, arg := range args {
 		if arg == "-config" && i+1 < len(args) {
 			return args[i+1]
+		}
+		if val, ok := strings.CutPrefix(arg, "-config="); ok {
+			return val
 		}
 	}
 	return config.FindConfigFile()

--- a/cmd/logwrap/main_test.go
+++ b/cmd/logwrap/main_test.go
@@ -438,6 +438,16 @@ func TestGetConfigFile_WithConfigFlag(t *testing.T) {
 			args:     []string{"-colors", "-config", "middle.yaml", "-utc"},
 			expected: "middle.yaml",
 		},
+		{
+			name:     "config with equals syntax",
+			args:     []string{"-config=/etc/logwrap/config.yaml"},
+			expected: "/etc/logwrap/config.yaml",
+		},
+		{
+			name:     "config equals syntax in middle of args",
+			args:     []string{"-colors", "-config=app.yaml", "-utc"},
+			expected: "app.yaml",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -170,24 +170,19 @@ func LoadConfig(configFile string, args []string) (*Config, error) {
 
 	applyCLIOverrides(config, flags)
 
+	// When detection is disabled, clear default keywords so the
+	// "disabled but keywords configured" validation does not reject
+	// configs that simply set detection.enabled: false. YAML
+	// unmarshaling merges maps and cannot clear pre-populated defaults.
+	if !config.LogLevel.Detection.Enabled {
+		config.LogLevel.Detection.Keywords = nil
+	}
+
 	// Apply color theme if set. Theme provides base colors; explicit
 	// color fields from the config file or CLI override theme values.
 	if config.Prefix.Colors.Theme != "" {
-		savedColors := config.Prefix.Colors
-
-		if err := applyTheme(&config.Prefix.Colors, config.Prefix.Colors.Theme); err != nil {
+		if err := applyThemeWithOverrides(&config.Prefix.Colors, explicit); err != nil {
 			return nil, fmt.Errorf("invalid configuration: %w", err)
-		}
-
-		// Restore colors explicitly set in the config file
-		if explicit.info {
-			config.Prefix.Colors.Info = savedColors.Info
-		}
-		if explicit.errColor {
-			config.Prefix.Colors.Error = savedColors.Error
-		}
-		if explicit.timestamp {
-			config.Prefix.Colors.Timestamp = savedColors.Timestamp
 		}
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -533,3 +533,35 @@ func TestApplyCLIOverrides(t *testing.T) {
 	assert.Equal(t, originalTemplate, cfg3.Prefix.Template)
 	assert.Equal(t, "text", cfg3.Output.Format) // Should keep default
 }
+
+func TestLoadConfig_DetectionDisabledClearsDefaultKeywords(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `
+prefix:
+  template: "[{{.Level}}] "
+  timestamp:
+    format: "%H:%M:%S"
+  user:
+    enabled: false
+    format: "username"
+  pid:
+    enabled: false
+    format: "decimal"
+output:
+  format: "text"
+log_level:
+  default_stdout: "INFO"
+  default_stderr: "ERROR"
+  detection:
+    enabled: false
+`
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(yamlContent), 0600))
+
+	cfg, err := LoadConfig(configPath, nil)
+	require.NoError(t, err, "detection.enabled: false should not fail validation")
+	assert.False(t, cfg.LogLevel.Detection.Enabled)
+	assert.Empty(t, cfg.LogLevel.Detection.Keywords, "keywords should be cleared when detection is disabled")
+}

--- a/pkg/config/themes.go
+++ b/pkg/config/themes.go
@@ -64,6 +64,28 @@ func applyTheme(colors *ColorsConfig, themeName string) error {
 	return nil
 }
 
+// applyThemeWithOverrides applies a theme and then restores any color fields
+// that were explicitly set in the config file.
+func applyThemeWithOverrides(colors *ColorsConfig, explicit explicitColorFields) error {
+	saved := *colors
+
+	if err := applyTheme(colors, colors.Theme); err != nil {
+		return err
+	}
+
+	if explicit.info {
+		colors.Info = saved.Info
+	}
+	if explicit.errColor {
+		colors.Error = saved.Error
+	}
+	if explicit.timestamp {
+		colors.Timestamp = saved.Timestamp
+	}
+
+	return nil
+}
+
 // ThemeNames returns the sorted list of available theme names.
 func ThemeNames() []string {
 	names := make([]string, 0, len(predefinedThemes))


### PR DESCRIPTION
- Clear detection keywords in LoadConfig when detection is disabled
  so YAML configs with detection.enabled: false pass validation
- Support -config=value equals syntax in getConfigFile using
  strings.CutPrefix
- Show color theme, color values, and filter settings in -validate
  output via extracted printColorSettings/printFilterSettings helpers
- Extract applyThemeWithOverrides to reduce LoadConfig cyclomatic
  complexity
- Extract printConfigSettings to reduce validateConfig cyclomatic
  complexity

Closes #66