### PR TITLE
fix(formatter,config): resolve template line duplication, filter-level validation, and regex validation

### DIFF
--- a/pkg/apperrors/apperrors.go
+++ b/pkg/apperrors/apperrors.go
@@ -26,6 +26,8 @@ var (
 	ErrEmptyKeyword                = errors.New("empty keyword in detection keywords")
 	ErrDetectionDisabledWithKeywords = errors.New("detection disabled but keywords are configured")
 	ErrEmptyFilterPattern            = errors.New("empty string in filter patterns is not allowed")
+	ErrFilterLevelsWithoutDetection  = errors.New("filter include_levels/exclude_levels require detection to be enabled")
+	ErrInvalidFilterPattern          = errors.New("invalid regex in filter pattern")
 )
 
 // Command line errors.

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"time"
@@ -333,17 +334,43 @@ func isValidLogLevel(level string, validLevels []string) bool {
 	return false
 }
 
-// validateFilter validates filter patterns.
+// validateFilter validates filter patterns and level-based filtering rules.
 //
 // Empty strings in exclude_patterns or include_patterns are rejected because
 // an empty regex matches every line, which would silently drop or pass all
 // output — almost certainly a configuration mistake.
+//
+// Level-based filter rules (include_levels, exclude_levels) require
+// detection to be enabled, since level detection is the mechanism
+// that assigns levels to lines. Without detection, all lines have
+// an empty detected level and level filters silently drop everything.
 func (c *Config) validateFilter() error {
+	if !c.LogLevel.Detection.Enabled {
+		if len(c.Filter.IncludeLevels) > 0 || len(c.Filter.ExcludeLevels) > 0 {
+			return apperrors.ErrFilterLevelsWithoutDetection
+		}
+	}
 	if slices.Contains(c.Filter.ExcludePatterns, "") {
 		return fmt.Errorf("%w in exclude_patterns", apperrors.ErrEmptyFilterPattern)
 	}
 	if slices.Contains(c.Filter.IncludePatterns, "") {
 		return fmt.Errorf("%w in include_patterns", apperrors.ErrEmptyFilterPattern)
+	}
+	if err := validateRegexPatterns(c.Filter.ExcludePatterns, "exclude_patterns"); err != nil {
+		return err
+	}
+	if err := validateRegexPatterns(c.Filter.IncludePatterns, "include_patterns"); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateRegexPatterns compiles each pattern to check for syntax errors.
+func validateRegexPatterns(patterns []string, field string) error {
+	for _, p := range patterns {
+		if _, err := regexp.Compile(p); err != nil {
+			return fmt.Errorf("%w %q in %s: %w", apperrors.ErrInvalidFilterPattern, p, field, err)
+		}
 	}
 	return nil
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1023,3 +1023,76 @@ func TestConfig_ValidateFilter_EmptyPatterns(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_ValidateFilter_LevelsRequireDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		detection   bool
+		include     []string
+		exclude     []string
+		expectError bool
+	}{
+		{"include_levels with detection enabled", true, []string{"ERROR"}, nil, false},
+		{"exclude_levels with detection enabled", true, nil, []string{"DEBUG"}, false},
+		{"include_levels with detection disabled", false, []string{"ERROR"}, nil, true},
+		{"exclude_levels with detection disabled", false, nil, []string{"DEBUG"}, true},
+		{"no level filters with detection disabled", false, nil, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := getDefaultConfig()
+			cfg.LogLevel.Detection.Enabled = tt.detection
+			if !tt.detection {
+				cfg.LogLevel.Detection.Keywords = nil
+			}
+			cfg.Filter.IncludeLevels = tt.include
+			cfg.Filter.ExcludeLevels = tt.exclude
+
+			err := cfg.Validate()
+			if tt.expectError {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, apperrors.ErrFilterLevelsWithoutDetection)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfig_ValidateFilter_InvalidRegex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		exclude     []string
+		include     []string
+		expectError bool
+	}{
+		{"valid regex patterns", []string{"^ERROR"}, []string{"important.*msg"}, false},
+		{"invalid exclude regex", []string{"[invalid"}, nil, true},
+		{"invalid include regex", nil, []string{"(unclosed"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := getDefaultConfig()
+			cfg.Filter.ExcludePatterns = tt.exclude
+			cfg.Filter.IncludePatterns = tt.include
+
+			err := cfg.Validate()
+			if tt.expectError {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, apperrors.ErrInvalidFilterPattern)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -77,11 +77,12 @@ const (
 // DefaultFormatter provides the default implementation of log line formatting.
 // It implements the [processor.Formatter] interface.
 type DefaultFormatter struct {
-	config   *config.Config
-	template *template.Template
-	userInfo *user.User
-	pid      int
-	colors   map[string]string
+	config           *config.Config
+	template         *template.Template
+	userInfo         *user.User
+	pid              int
+	colors           map[string]string
+	templateUsesLine bool
 }
 
 // TemplateData contains the data available for template rendering.
@@ -125,11 +126,12 @@ func New(cfg *config.Config) (*DefaultFormatter, error) {
 	}
 
 	return &DefaultFormatter{
-		config:   cfg,
-		template: tmpl,
-		userInfo: userInfo,
-		pid:      os.Getpid(),
-		colors:   colors,
+		config:           cfg,
+		template:         tmpl,
+		userInfo:         userInfo,
+		pid:              os.Getpid(),
+		colors:           colors,
+		templateUsesLine: strings.Contains(cfg.Prefix.Template, ".Line"),
 	}, nil
 }
 
@@ -152,6 +154,15 @@ func (f *DefaultFormatter) formatText(data TemplateData) string {
 	builder.Grow(estimatedPrefixLen + len(data.Line))
 	if err := f.template.Execute(&builder, data); err != nil {
 		return data.Line
+	}
+
+	// When the template already includes {{.Line}}, it produces
+	// the complete output — don't append the line again.
+	if f.templateUsesLine {
+		if f.config.Prefix.Colors.Enabled {
+			return f.colorizePrefix(builder.String())
+		}
+		return builder.String()
 	}
 
 	if f.config.Prefix.Colors.Enabled {

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -1343,3 +1343,59 @@ func TestFormatLine_Structured_DisabledUserPID(t *testing.T) {
 	assert.NotContains(t, result, "user=", "user field should be omitted when disabled")
 	assert.NotContains(t, result, "pid=", "pid field should be omitted when disabled")
 }
+
+func TestFormatLine_TemplateWithLine_NoDuplication(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Prefix: config.PrefixConfig{
+			Template: "[{{.Level}}] {{.Line}}",
+			Timestamp: config.TimestampConfig{
+				Format: "%H:%M:%S",
+			},
+			Colors: config.ColorsConfig{Enabled: false},
+			User:   config.UserConfig{Enabled: false},
+			PID:    config.PIDConfig{Enabled: false},
+		},
+		Output: config.OutputConfig{Format: "text"},
+		LogLevel: config.LogLevelConfig{
+			DefaultStdout: "INFO",
+			DefaultStderr: "ERROR",
+			Detection:     config.DetectionConfig{Enabled: false},
+		},
+	}
+
+	formatter, err := New(cfg)
+	require.NoError(t, err)
+
+	result := formatter.FormatLine("hello world", processor.StreamStdout)
+	assert.Equal(t, "[INFO] hello world", result, "line should not be duplicated when template includes {{.Line}}")
+}
+
+func TestFormatLine_TemplateWithoutLine_AppendsLine(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		Prefix: config.PrefixConfig{
+			Template: "[{{.Level}}] ",
+			Timestamp: config.TimestampConfig{
+				Format: "%H:%M:%S",
+			},
+			Colors: config.ColorsConfig{Enabled: false},
+			User:   config.UserConfig{Enabled: false},
+			PID:    config.PIDConfig{Enabled: false},
+		},
+		Output: config.OutputConfig{Format: "text"},
+		LogLevel: config.LogLevelConfig{
+			DefaultStdout: "INFO",
+			DefaultStderr: "ERROR",
+			Detection:     config.DetectionConfig{Enabled: false},
+		},
+	}
+
+	formatter, err := New(cfg)
+	require.NoError(t, err)
+
+	result := formatter.FormatLine("hello world", processor.StreamStdout)
+	assert.Equal(t, "[INFO] hello world", result, "line should be appended when template does not include {{.Line}}")
+}


### PR DESCRIPTION
- Skip appending line in formatText when template already includes
  {{.Line}} via new templateUsesLine flag on DefaultFormatter
- Reject filter include_levels/exclude_levels when detection is
  disabled since level detection is required for level-based filtering
- Validate regex syntax for filter patterns during config validation
  so -validate catches invalid patterns before runtime
- Add ErrFilterLevelsWithoutDetection and ErrInvalidFilterPattern
  sentinel errors
- Add tests for all three fixes

Closes #68