### PR TITLE
fix(config): validate filter level names against allowed log levels

### DIFF
--- a/pkg/apperrors/apperrors.go
+++ b/pkg/apperrors/apperrors.go
@@ -28,6 +28,7 @@ var (
 	ErrEmptyFilterPattern            = errors.New("empty string in filter patterns is not allowed")
 	ErrFilterLevelsWithoutDetection  = errors.New("filter include_levels/exclude_levels require detection to be enabled")
 	ErrInvalidFilterPattern          = errors.New("invalid regex in filter pattern")
+	ErrInvalidFilterLevel            = errors.New("invalid log level in filter")
 )
 
 // Command line errors.

--- a/pkg/config/validation.go
+++ b/pkg/config/validation.go
@@ -345,10 +345,18 @@ func isValidLogLevel(level string, validLevels []string) bool {
 // that assigns levels to lines. Without detection, all lines have
 // an empty detected level and level filters silently drop everything.
 func (c *Config) validateFilter() error {
+	validLevels := []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"}
+
 	if !c.LogLevel.Detection.Enabled {
 		if len(c.Filter.IncludeLevels) > 0 || len(c.Filter.ExcludeLevels) > 0 {
 			return apperrors.ErrFilterLevelsWithoutDetection
 		}
+	}
+	if err := validateFilterLevelNames(c.Filter.IncludeLevels, "include_levels", validLevels); err != nil {
+		return err
+	}
+	if err := validateFilterLevelNames(c.Filter.ExcludeLevels, "exclude_levels", validLevels); err != nil {
+		return err
 	}
 	if slices.Contains(c.Filter.ExcludePatterns, "") {
 		return fmt.Errorf("%w in exclude_patterns", apperrors.ErrEmptyFilterPattern)
@@ -361,6 +369,18 @@ func (c *Config) validateFilter() error {
 	}
 	if err := validateRegexPatterns(c.Filter.IncludePatterns, "include_patterns"); err != nil {
 		return err
+	}
+	return nil
+}
+
+// validateFilterLevelNames checks that all level names in the list are valid
+// log levels. This prevents typos from silently dropping all output.
+func validateFilterLevelNames(levels []string, field string, validLevels []string) error {
+	for _, level := range levels {
+		if !isValidLogLevel(strings.ToUpper(level), validLevels) {
+			return fmt.Errorf("%w %q in %s, valid levels: %s",
+				apperrors.ErrInvalidFilterLevel, level, field, strings.Join(validLevels, ", "))
+		}
 	}
 	return nil
 }

--- a/pkg/config/validation_test.go
+++ b/pkg/config/validation_test.go
@@ -1096,3 +1096,42 @@ func TestConfig_ValidateFilter_InvalidRegex(t *testing.T) {
 		})
 	}
 }
+
+func TestConfig_ValidateFilter_InvalidLevelNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		include     []string
+		exclude     []string
+		expectError bool
+	}{
+		{"valid uppercase levels", []string{"ERROR", "WARN"}, nil, false},
+		{"valid lowercase levels", []string{"error", "warn"}, nil, false},
+		{"valid mixed include and exclude", []string{"ERROR"}, []string{"DEBUG"}, false},
+		{"all valid levels", []string{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"}, nil, false},
+		{"typo in include", []string{"EROR"}, nil, true},
+		{"typo in exclude", nil, []string{"DEBU"}, true},
+		{"completely invalid", []string{"INVALID_LEVEL"}, nil, true},
+		{"mixed valid and invalid", []string{"ERROR", "INVALID"}, nil, true},
+		{"empty list is fine", nil, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := getDefaultConfig()
+			cfg.Filter.IncludeLevels = tt.include
+			cfg.Filter.ExcludeLevels = tt.exclude
+
+			err := cfg.Validate()
+			if tt.expectError {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, apperrors.ErrInvalidFilterLevel)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add validateFilterLevelNames to reject invalid level names in
  filter include_levels and exclude_levels during config validation
- Typos like "EROR" or invalid names like "INVALID_LEVEL" now
  produce a clear error listing valid levels instead of silently
  dropping all output at runtime
- Add ErrInvalidFilterLevel sentinel error
- Add TestConfig_ValidateFilter_InvalidLevelNames covering valid,
  lowercase, typo, and invalid level name cases

Closes #70