### PR TITLE
fix(main): support -flag=true syntax for -validate, -help, and -version

### DIFF
--- a/cmd/logwrap/main.go
+++ b/cmd/logwrap/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"slices"
 	"strings"
 	"syscall"
 	"time"
@@ -135,7 +134,7 @@ func validateConfig(args []string) int {
 	// not a config flag and would be rejected by the flag parser.
 	var filteredArgs []string
 	for _, arg := range args {
-		if arg != "-validate" {
+		if arg != "-validate" && arg != "-validate=true" {
 			filteredArgs = append(filteredArgs, arg)
 		}
 	}
@@ -243,7 +242,12 @@ func parseArgs(args []string) ([]string, []string, error) {
 }
 
 func hasFlag(args []string, flag string) bool {
-	return slices.Contains(args, flag)
+	for _, arg := range args {
+		if arg == flag || arg == flag+"=true" {
+			return true
+		}
+	}
+	return false
 }
 
 func getConfigFile(args []string) string {

--- a/cmd/logwrap/main_test.go
+++ b/cmd/logwrap/main_test.go
@@ -493,6 +493,30 @@ func TestHasFlag_EdgeCases(t *testing.T) {
 			flag:     "colors",
 			expected: true, // "colors" appears as an argument
 		},
+		{
+			name:     "flag with =true suffix",
+			args:     []string{"-validate=true"},
+			flag:     "-validate",
+			expected: true,
+		},
+		{
+			name:     "flag with =false suffix not matched",
+			args:     []string{"-validate=false"},
+			flag:     "-validate",
+			expected: false,
+		},
+		{
+			name:     "help with =true suffix",
+			args:     []string{"-help=true"},
+			flag:     "-help",
+			expected: true,
+		},
+		{
+			name:     "version with =true suffix",
+			args:     []string{"-version=true"},
+			flag:     "-version",
+			expected: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
- Update hasFlag to match both exact flag and flag=true suffix so
  -validate=true, -help=true, -version=true trigger correctly
- Update validateConfig filter to also remove -validate=true before
  passing args to the flag parser
- Add hasFlag test cases for =true and =false suffixes

Closes #74